### PR TITLE
fix: Repository URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+doc-serve:
+	docfx ./docs/docfx.json --serve
+
+.PHONY: doc-serve

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,4 +9,4 @@ Includes a few simple utility classes.
 
 ## Links
 
-- [GitHub Repository](https://github.com/kawana77b/Direct-Capture)
+- [GitHub Repository](https://github.com/kawana77b/DirectCapture)

--- a/src/DirectCapture/DirectCapture.csproj
+++ b/src/DirectCapture/DirectCapture.csproj
@@ -10,13 +10,16 @@
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 
-		<Version>0.5.0</Version>
+		<Version>0.5.1</Version>
+		<PackageId>DirectCapture</PackageId>
+		<Title>DirectCapture</Title>
 		<Authors>Shimarisu121</Authors>
 		<Description>C# library aimed at capturing AVI files playable in DirectShow as Bitmap.</Description>
-		<Title>DirectCapture</Title>
-		<Copyright>(c) shimarisu121</Copyright>
+		<Copyright>Copyright $([System.DateTime]::Now.Year) shimarisu121</Copyright>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<RepositoryUrl>https://github.com/kawana77b/Direct-Capture</RepositoryUrl>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<RepositoryUrl>https://github.com/kawana77b/DirectCapture</RepositoryUrl>
+		<PackageProjectUrl>https://github.com/kawana77b/DirectCapture</PackageProjectUrl>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0-windows|AnyCPU'">


### PR DESCRIPTION
fix #2 
Edit the repository URL.
Also, increase the information to be included in the csproj for package distribution.

Additional:
Add an additional Makefile to launch the docfx local server as a shortcut